### PR TITLE
Add first name, last name, and username to devise

### DIFF
--- a/app/assets/stylesheets/signupstyle.css
+++ b/app/assets/stylesheets/signupstyle.css
@@ -1,0 +1,12 @@
+.signup-error-box {
+  background-color: rgb(178, 34, 34);
+  margin-right: 1rem;
+}
+
+.field {
+  margin-right: 1rem;
+}
+
+.signup {
+  margin-left: 1rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,14 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
+  protect_from_forgery unless: -> { request.format.json? }
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :username])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  validates :username, presence: true, uniqueness: true
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,8 +4,13 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name, autofocus: true, autocomplete: "first-name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,45 @@
-<h2>Sign up</h2>
+<div class="signup">
+  <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :first_name %><br />
-    <%= f.text_field :first_name, autofocus: true, autocomplete: "first-name" %>
+    <div class="field">
+      <%= f.label :first_name %><br />
+      <%= f.text_field :first_name, autofocus: true %>
+    </div>
+
+    <div class="field">
+      <%= f.label :last_name %><br />
+      <%= f.text_field :last_name %>
+    </div>
+
+    <div class="field">
+      <%= f.label :username %><br />
+      <%= f.text_field :username %>
+    </div>
+
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %>
+      <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Sign up" %>
+    </div>
+  <% end %>
+  <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
+  <div id="error_explanation" class="callout signup-error-box">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,4 +57,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,14 +8,13 @@
 #
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
-Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
-
+Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '8fc73e88ed35f7e57f01ad050a9d48ce75fc8dcf667dc4e7b6bc1f03298121d4e1a69a0664ecf81dc2ec4550e4bb56d3b18ad7b2b8d9635a1ab2ea3c94ff19cf'
+  # config.secret_key = '7ca31fdc47ee6d62adc518553a6c2154a53096dd10a787f72ab27343329b665dffa1cc057a8476e1cff810d7f305abff606bac5189af609b5ff4f84a16e2f424'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -127,7 +126,7 @@ Devise.setup do |config|  config.secret_key = Rails.application.secret_key_base
   config.stretches = Rails.env.test? ? 1 : 12
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '63bfbe9c1d86ea7911ff6c23e3df56051a85e2dca2da5ec28cdc374407c7fcfda959d5615646a69d2d42267dd5cf16a5362d3e28ebf1257b5c2b33925c81f642'
+  # config.pepper = '43ce68d9d0dc410bcdd36c5748722a55dbd4ec2cfe76b950a4931dcc2267b4744f34d4c5244a0b9ec221c586b829f8bd5b81b34d0246fb46c74527fb3c7fb2ee'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false

--- a/db/migrate/20200722143246_add_columns_to_users_table.rb
+++ b/db/migrate/20200722143246_add_columns_to_users_table.rb
@@ -1,0 +1,7 @@
+class AddColumnsToUsersTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :first_name, :string, null: false
+    add_column :users, :last_name, :string, null: false
+    add_column :users, :username, :string, null: false
+  end
+end

--- a/db/migrate/20200722190412_add_username_uniqueness.rb
+++ b/db/migrate/20200722190412_add_username_uniqueness.rb
@@ -1,0 +1,5 @@
+class AddUsernameUniqueness < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, :username, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_142436) do
+ActiveRecord::Schema.define(version: 2020_07_22_143246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,9 @@ ActiveRecord::Schema.define(version: 2020_07_21_142436) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -44,5 +47,5 @@ ActiveRecord::Schema.define(version: 2020_07_21_142436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-  
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_143246) do
+ActiveRecord::Schema.define(version: 2020_07_22_190412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2020_07_22_143246) do
     t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   create_table "videogames", force: :cascade do |t|

--- a/spec/features/user_signs_up_spec.rb
+++ b/spec/features/user_signs_up_spec.rb
@@ -16,6 +16,9 @@ feature 'user registers', %Q{
     visit new_user_registration_path
 
     fill_in 'Email', with: 'john@example.com'
+    fill_in 'First name', with: 'John'
+    fill_in 'Last name', with: 'Jones'
+    fill_in 'Username', with: 'johnjones22'
     fill_in 'Password', with: 'password'
     fill_in 'Password confirmation', with: 'password'
 

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -2,7 +2,10 @@ require 'factory_bot'
 
 FactoryBot.define do
   factory :user do
-    sequence(:email) {|n| "user#{n}@example.com" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    first_name { 'John' }
+    last_name { 'Jones' }
+    sequence(:username) { |n| "username#{n}" }
     password { 'password' }
     password_confirmation { 'password' }
   end


### PR DESCRIPTION
1. Created a migration that added first name, last name, and username to the user table.
2. Added protection to so devise will only take in parameters that we permit.
3. Updated form to take in first name, last name, and username upon sign up.
4. Added validations for uniqueness (username) and presences for all fields. 
5. Added action mailer default url options for development.
6. Updated factorybot user sign up spec test to fill in new fields.
7. Added uniqueness on database level for username.
8. Initial styling for sign up form.